### PR TITLE
Add feature to configure offset for total sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Sums time spent per day and calculates the difference to the daily target. The
 default is 8 hours. It can be changed by setting the config variable
 `flextime.hours_per_day`.
 
+If you already have overtime, you can have flextime take it into account by
+setting the config variable `flextime.minutes_offset_total`.
+
 #### Install
 
 After cloning the repo, build directly into your timewarrior extensions

--- a/cmd/flextime/config.go
+++ b/cmd/flextime/config.go
@@ -32,12 +32,22 @@ func readConfig(reader *twext.Reader) (config, error) {
 		return config{}, fmt.Errorf("read config section: %w", err)
 	}
 
-	dailyTarget, err := configReadDuration(rawCfg, configKeyHoursPerDay, defaultDailyTarget, time.Hour)
+	dailyTarget, err := configReadDuration(
+		rawCfg,
+		configKeyHoursPerDay,
+		defaultDailyTarget,
+		time.Hour,
+	)
 	if err != nil {
 		return config{}, fmt.Errorf("get daily target: %w", err)
 	}
 
-	offset, err := configReadDuration(rawCfg, configKeyOffsetTotal, defaultOffsetTotal, time.Minute)
+	offset, err := configReadDuration(
+		rawCfg,
+		configKeyOffsetTotal,
+		defaultOffsetTotal,
+		time.Minute,
+	)
 	if err != nil {
 		return config{}, fmt.Errorf("get total offset: %w", err)
 	}

--- a/cmd/flextime/main.go
+++ b/cmd/flextime/main.go
@@ -43,7 +43,15 @@ func printSums(p *printer, daySums daySums) error {
 		return fmt.Errorf("write header: %w", err)
 	}
 
-	var total time.Duration
+	total := p.cfg.offset
+
+	if p.cfg.offset != 0 && p.cfg.verbose {
+		err = p.writeTime("offset", p.cfg.offset, 0)
+		if err != nil {
+			return fmt.Errorf("write offset: %w", err)
+		}
+	}
+
 	for day, daySum := range daySums.Sorted() {
 		total += daySum
 

--- a/cmd/flextime/main.go
+++ b/cmd/flextime/main.go
@@ -32,6 +32,7 @@ func sumDuration(result time.Duration, entry twext.Entry) time.Duration {
 	return result + entry.Duration()
 }
 
+//nolint:cyclop
 func printSums(p *printer, daySums daySums) error {
 	_, err := fmt.Fprintln(p.writer)
 	if err != nil {
@@ -46,7 +47,7 @@ func printSums(p *printer, daySums daySums) error {
 	total := p.cfg.offset
 
 	if p.cfg.offset != 0 && p.cfg.verbose {
-		err = p.writeTime("offset", p.cfg.offset, 0)
+		err := p.writeTime("offset", p.cfg.offset, 0)
 		if err != nil {
 			return fmt.Errorf("write offset: %w", err)
 		}

--- a/cmd/flextime/main_internal_test.go
+++ b/cmd/flextime/main_internal_test.go
@@ -29,6 +29,7 @@ func TestRun(t *testing.T) {
 			name: "quiet",
 			input: `verbose: off
 flextime.hours_per_day: 4
+flextime.minutes_offset_total: 60
 
 [
 {"id":3,"start":"20240629T102128Z","end":"20240629T102131Z"},
@@ -37,7 +38,7 @@ flextime.hours_per_day: 4
 ]`,
 			expectedStdout: `
      date    actual    target       diff
-    total    1h:59m    8h:00m    -6h:00m
+    total    2h:59m    8h:00m    -5h:00m
 `,
 		},
 		{
@@ -54,6 +55,42 @@ flextime.hours_per_day: 4
     2024-06-29    0h:00m     8h:00m     -7h:59m
     2024-06-30    1h:59m     8h:00m     -6h:00m
          total    1h:59m    16h:00m    -14h:00m
+`,
+		},
+		{
+			name: "positive offset",
+			input: `verbose: on
+flextime.minutes_offset_total: 90
+
+[
+{"id":3,"start":"20240629T102128Z","end":"20240629T102131Z"},
+{"id":2,"start":"20240630T143940Z","end":"20240630T143943Z"},
+{"id":1,"start":"20240630T144010Z","end":"20240630T163943Z"}
+]`,
+			expectedStdout: `
+          date    actual     target        diff
+        offset    1h:30m     0h:00m      1h:30m
+    2024-06-29    0h:00m     8h:00m     -7h:59m
+    2024-06-30    1h:59m     8h:00m     -6h:00m
+         total    3h:29m    16h:00m    -12h:30m
+`,
+		},
+		{
+			name: "negative offset",
+			input: `verbose: on
+flextime.minutes_offset_total: -70
+
+[
+{"id":3,"start":"20240629T102128Z","end":"20240629T102131Z"},
+{"id":2,"start":"20240630T143940Z","end":"20240630T143943Z"},
+{"id":1,"start":"20240630T144010Z","end":"20240630T163943Z"}
+]`,
+			expectedStdout: `
+          date     actual     target        diff
+        offset    -1h:10m     0h:00m     -1h:10m
+    2024-06-29     0h:00m     8h:00m     -7h:59m
+    2024-06-30     1h:59m     8h:00m     -6h:00m
+         total     0h:49m    16h:00m    -15h:10m
 `,
 		},
 		{


### PR DESCRIPTION
When starting to use timewarrior one might already have overtime, so I propose to add a setting that let's one define an offset that will be added to the sum.

At the moment the command output looks like this:
```
          date       actual       target        diff
    2024-07-15       8h:07m       8h:00m      0h:07m
           ...          ...          ...         ...
    2025-02-12       8h:01m       8h:00m      0h:01m
    2025-02-13       8h:56m       8h:00m      0h:56m
    2025-02-14       0h:57m       8h:00m     -7h:02m
     sub-total    1008h:54m    1024h:00m    -15h:05m
        offset       8h:51m       0h:00m      8h:51m
         total    1017h:45m    1024h:00m     -6h:14m
```

With the new option configured:
```
flextime.offset_total_by_minutes = 531
```

I'm open to suggestions on how to format / name the different parameters. Options I thought about:
* Put the offset at the very top
* Omit the sub-total
* Name the config option differently (e.g. `flextime.offset_minutes`, ...)