### PR TITLE
Add configurable cross-day aggregation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,23 @@ flextime take it into account by setting a global offset.
 
 The following configuration keys are supported:
 
-| Key                     | Type     | Default | Description                                   |
-|-------------------------|----------|---------|-----------------------------------------------|
-| `flextime.time_per_day` | Duration | `8h`    | Daily time target.                            |
-| `flextime.offset_total` | Duration | `0`     | Time spent or lacking from a previous period. |
-| `verbose`               | Bool     | true    | Print daily sums.                             |
-| `debug`                 | Bool     | false   | Enable debug output.                          |
+| Key                             | Type     | Default           | Description                                   |
+|---------------------------------|----------|-------------------|-----------------------------------------------|
+| `flextime.time_per_day`         | Duration | `8h`              | Daily time target.                            |
+| `flextime.offset_total`         | Duration | `0`               | Time spent or lacking from a previous period. |
+| `flextime.aggregation_strategy` | Enum     | `single-day-only` | Strategy to use for aggregating the entries.  |
+| `verbose`                       | Bool     | true              | Print daily sums.                             |
+| `debug`                         | Bool     | false             | Enable debug output.                          |
 
 Durations must be given in a format supported by
 [go's time duration parser][go-time-duration].
+
+| Aggregation Strategy | Description                                                                |
+|----------------------|----------------------------------------------------------------------------|
+| `single-day-only`    | Discard entries spanning multiple days.                                    |
+| `into-start-date`    | Count entries spanning multiple days for the day that the entry starts on. |
+| `into-end-date`      | Count entries spanning multiple days for the day that the entry end on.    |
+| `split-at-midnight`  | Split entries spanning over multiple days at midnight.                     |
 
 #### Install
 

--- a/cmd/flextime/aggregation.go
+++ b/cmd/flextime/aggregation.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2024 Tobias Böhm <code@aibor.de>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aibor/timewarrior-extensions/twext"
+)
+
+type entriesTransformation func(entries twext.Entries) twext.Entries
+
+type aggregationStrategy[K twext.GroupKey, V any] struct {
+	name      string
+	keyFn     twext.GroupKeyFunc[K]
+	valueFn   twext.GroupValueFunc[V]
+	transform entriesTransformation
+}
+
+func (s *aggregationStrategy[K, V]) String() string {
+	return s.name
+}
+
+func (s *aggregationStrategy[K, V]) Aggregate(
+	entries twext.Entries,
+) twext.Groups[K, V] {
+	return twext.Group(
+		s.transform(entries),
+		s.keyFn,
+		s.valueFn,
+	)
+}
+
+func startDate(entry twext.Entry) string {
+	return entry.Start.Format(time.DateOnly)
+}
+
+func endDate(entry twext.Entry) string {
+	return entry.End.Format(time.DateOnly)
+}
+
+func sumDuration(result time.Duration, entry twext.Entry) time.Duration {
+	return result + entry.Duration()
+}
+
+func onlySingleDays(entry twext.Entry) bool {
+	sameDate := entry.Start.SameDate(entry.CurrentEnd())
+	if !sameDate {
+		log.Printf("entry %d spans multiple days. Skipping.", entry.ID)
+	}
+
+	return sameDate
+}
+
+var errUnknownAggregationStrategy = errors.New("unknown aggregation strategy")
+
+func createAggregationStrategy(
+	strategy string,
+) (*aggregationStrategy[string, time.Duration], error) {
+	switch strategy {
+	case "single-day-only":
+		return &aggregationStrategy[string, time.Duration]{
+			name:    strategy,
+			keyFn:   startDate,
+			valueFn: sumDuration,
+			transform: func(entries twext.Entries) twext.Entries {
+				return entries.Filter(onlySingleDays)
+			},
+		}, nil
+	case "into-start-date":
+		return &aggregationStrategy[string, time.Duration]{
+			name:      strategy,
+			keyFn:     startDate,
+			valueFn:   sumDuration,
+			transform: func(entries twext.Entries) twext.Entries { return entries },
+		}, nil
+	case "into-end-date":
+		return &aggregationStrategy[string, time.Duration]{
+			name:      strategy,
+			keyFn:     endDate,
+			valueFn:   sumDuration,
+			transform: func(entries twext.Entries) twext.Entries { return entries },
+		}, nil
+	case "split-at-midnight":
+		return &aggregationStrategy[string, time.Duration]{
+			name:    strategy,
+			keyFn:   startDate,
+			valueFn: sumDuration,
+			transform: func(entries twext.Entries) twext.Entries {
+				return entries.SplitAtMidnight()
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("%w: %s", errUnknownAggregationStrategy, strategy)
+	}
+}

--- a/cmd/flextime/aggregation_test.go
+++ b/cmd/flextime/aggregation_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2024 Tobias Böhm <code@aibor.de>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aibor/timewarrior-extensions/twext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName(t *testing.T) {
+	name := "my-custom-strategy"
+	strategy := aggregationStrategy[string, int]{
+		name:      name,
+		keyFn:     nil,
+		valueFn:   nil,
+		transform: nil,
+	}
+
+	assert.Equal(t, name, strategy.String())
+}
+
+func TestStartDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    twext.Entry
+		expected string
+	}{
+		{
+			name: "single day",
+			input: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100203T102030Z"),
+			},
+			expected: "2010-02-03",
+		},
+		{
+			name: "multi day",
+			input: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100204T031125Z"),
+			},
+			expected: "2010-02-03",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, startDate(tt.input))
+		})
+	}
+}
+
+func TestEndDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    twext.Entry
+		expected string
+	}{
+		{
+			name: "single day",
+			input: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100203T102030Z"),
+			},
+			expected: "2010-02-03",
+		},
+		{
+			name: "multi day",
+			input: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100204T031125Z"),
+			},
+			expected: "2010-02-04",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, endDate(tt.input))
+		})
+	}
+}
+
+func TestSumDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    twext.Entry
+		base     time.Duration
+		expected time.Duration
+	}{
+		{
+			name: "short duration initial",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100203T102030Z"),
+			},
+			base:     0,
+			expected: 5 * time.Minute,
+		},
+		{
+			name: "short duration accumulates",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100203T102030Z"),
+			},
+			base:     15 * time.Minute,
+			expected: 20 * time.Minute,
+		},
+		{
+			name: "cross-day duration initial",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T234530Z"),
+				End:   twext.MustParseTime(t, "20100204T001530Z"),
+			},
+			base:     0,
+			expected: 30 * time.Minute,
+		},
+		{
+			name: "cross-day duration initial",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T234530Z"),
+				End:   twext.MustParseTime(t, "20100204T001530Z"),
+			},
+			base:     30 * time.Minute,
+			expected: 1 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sum := sumDuration(tt.base, tt.entry)
+			assert.Equal(t, tt.expected, sum)
+		})
+	}
+}
+
+func TestOnlySingleDays(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    twext.Entry
+		expected bool
+	}{
+		{
+			name: "single day",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T101530Z"),
+				End:   twext.MustParseTime(t, "20100203T102030Z"),
+			},
+			expected: true,
+		},
+		{
+			name: "multi day",
+			entry: twext.Entry{
+				Start: twext.MustParseTime(t, "20100203T234530Z"),
+				End:   twext.MustParseTime(t, "20100204T001530Z"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, onlySingleDays(tt.entry))
+		})
+	}
+}

--- a/cmd/flextime/config.go
+++ b/cmd/flextime/config.go
@@ -12,18 +12,21 @@ import (
 )
 
 const (
-	configKeyPrefix      = "flextime"
-	configKeyDailyTarget = "time_per_day"
-	defaultDailyTarget   = "8h"
-	configKeyOffsetTotal = "offset_total"
-	defaultOffsetTotal   = "0"
+	configKeyPrefix              = "flextime"
+	configKeyDailyTarget         = "time_per_day"
+	defaultDailyTarget           = "8h"
+	configKeyOffsetTotal         = "offset_total"
+	defaultOffsetTotal           = "0"
+	configKeyAggregationStrategy = "aggregation_strategy"
+	defaultAggregationStrategy   = "single-day-only"
 )
 
 type config struct {
-	dailyTarget time.Duration
-	offset      time.Duration
-	debug       bool
-	verbose     bool
+	dailyTarget         time.Duration
+	offset              time.Duration
+	aggregationStrategy *aggregationStrategy[string, time.Duration]
+	debug               bool
+	verbose             bool
 }
 
 func readConfig(reader *twext.Reader) (config, error) {
@@ -32,50 +35,79 @@ func readConfig(reader *twext.Reader) (config, error) {
 		return config{}, fmt.Errorf("read config section: %w", err)
 	}
 
-	dailyTarget, err := configReadDuration(
+	dailyTarget, err := configRead(
 		rawCfg,
 		configKeyDailyTarget,
 		defaultDailyTarget,
+		parseDuration,
 	)
 	if err != nil {
 		return config{}, fmt.Errorf("get daily target: %w", err)
 	}
 
-	offset, err := configReadDuration(
+	offset, err := configRead(
 		rawCfg,
 		configKeyOffsetTotal,
 		defaultOffsetTotal,
+		parseDuration,
 	)
 	if err != nil {
 		return config{}, fmt.Errorf("get total offset: %w", err)
 	}
 
+	strategy, err := configRead(
+		rawCfg,
+		configKeyAggregationStrategy,
+		defaultAggregationStrategy,
+		parseAggregationStrategy,
+	)
+	if err != nil {
+		return config{}, fmt.Errorf("get aggregation strategy: %w", err)
+	}
+
 	cfg := config{
-		dailyTarget: dailyTarget,
-		offset:      offset,
-		debug:       rawCfg[twext.ConfigKeyDebug].Bool(),
-		verbose:     rawCfg[twext.ConfigKeyVerbose].Bool(),
+		dailyTarget:         dailyTarget,
+		offset:              offset,
+		aggregationStrategy: strategy,
+		debug:               rawCfg[twext.ConfigKeyDebug].Bool(),
+		verbose:             rawCfg[twext.ConfigKeyVerbose].Bool(),
 	}
 
 	return cfg, nil
 }
 
-func configReadDuration(
+func configRead[R any](
 	twConfig twext.Config,
 	cfgKey string,
-	defValue string,
-) (time.Duration, error) {
+	defValue twext.ConfigValue,
+	parseValue func(twext.ConfigValue) (R, error),
+) (R, error) {
 	key := twext.NewConfigKey(configKeyPrefix, cfgKey)
 
 	cfgValue, exists := twConfig[key]
 	if !exists {
-		cfgValue = twext.ConfigValue(defValue)
+		cfgValue = defValue
 	}
 
-	duration, err := cfgValue.Duration()
+	return parseValue(cfgValue)
+}
+
+func parseDuration(value twext.ConfigValue) (time.Duration, error) {
+	duration, err := value.Duration()
 	if err != nil {
 		return 0, fmt.Errorf("convert to duration: %w", err)
 	}
 
 	return duration, nil
+}
+
+func parseAggregationStrategy(
+	value twext.ConfigValue,
+) (*aggregationStrategy[string, time.Duration], error) {
+	strategy, err := createAggregationStrategy(value.String())
+	if err != nil {
+		return nil, fmt.Errorf("create aggregation strategy: %w", err)
+	}
+
+	return strategy, nil
 }

--- a/cmd/flextime/config.go
+++ b/cmd/flextime/config.go
@@ -76,6 +76,7 @@ func readConfig(reader *twext.Reader) (config, error) {
 	return cfg, nil
 }
 
+//nolint:ireturn,nolintlint
 func configRead[R any](
 	twConfig twext.Config,
 	cfgKey string,

--- a/twext/entry.go
+++ b/twext/entry.go
@@ -23,16 +23,30 @@ type Entry struct {
 //
 // If the [Entry] is still active, the current time is used as the end time.
 func (e *Entry) Duration() time.Duration {
-	end := e.End
-	if end.IsZero() {
-		end.Time = time.Now()
-	}
+	end := e.CurrentEnd()
 
 	if end.Before(e.Start.Time) {
 		return 0
 	}
 
 	return end.Sub(e.Start.Time)
+}
+
+// CurrentEnd calculates the actual end of the [Entry].
+//
+// If the [Entry] is still active, the current time is returned.
+// Otherwise, the recorded time is returned.
+func (e *Entry) CurrentEnd() *Time {
+	if e.IsActive() {
+		return &Time{time.Now()}
+	}
+
+	return &e.End
+}
+
+// IsActive checks if this [Entry] is still active.
+func (e *Entry) IsActive() bool {
+	return e.End.IsZero()
 }
 
 // Entries is a list of [Entry]s.
@@ -51,4 +65,62 @@ func readEntries(reader io.Reader) (Entries, error) {
 	}
 
 	return entries, nil
+}
+
+// Filter removes entries that do not match the filter.
+func (e Entries) Filter(filter func(entry Entry) bool) Entries {
+	entries := make(Entries, 0, len(e))
+
+	for _, entry := range e {
+		if filter(entry) {
+			entries = appendAsSingleDayEntries(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+// SplitAtMidnight creates a list of single-day entries.
+//
+// The [Entry.ID] will be copied when an [Entry] is split, causing multiple
+// entries with the same ID to exist.
+// The covered sum of durations does not change.
+func (e Entries) SplitAtMidnight() Entries {
+	entries := make(Entries, 0, len(e))
+	for _, entry := range e {
+		entries = appendAsSingleDayEntries(entries, entry)
+	}
+
+	return entries
+}
+
+func appendAsSingleDayEntries(entries Entries, entry Entry) Entries {
+	end := entry.CurrentEnd()
+	for !entry.Start.SameDate(end) {
+		midnight := Time{Time: time.Date(
+			entry.Start.Year(),
+			entry.Start.Month(),
+			entry.Start.Day(),
+			0, 0, 0, 0,
+			entry.Start.Location(),
+		).AddDate(0, 0, 1)}
+
+		entries = append(entries, Entry{
+			ID:    entry.ID,
+			Start: entry.Start,
+			End:   midnight,
+			Tags:  entry.Tags,
+		})
+
+		entry = Entry{
+			ID:    entry.ID,
+			Start: midnight,
+			End:   entry.End,
+			Tags:  entry.Tags,
+		}
+	}
+
+	entries = append(entries, entry)
+
+	return entries
 }


### PR DESCRIPTION
This is my current draft for #4. Let's discuss about it!

Open topics:
* Naming is not consistent, I went with both `aggregation` and `cross-day handling` and mixed it all over the place. I'm not quite happy with either name.
* The need to add a new error just for this single case; err113 complains otherwise. Maybe that error should be more general and be used in all parsing methods?
* The large chunks of code added to the main, it might be a good idea to extract them elsewhere.

Please let me know what you think.

This PR closes #4.