### PR TITLE
Add configurable target time per weekday

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Durations must be given in a format supported by
 | `into-end-date`      | Count entries spanning multiple days for the day that the entry end on.    |
 | `split-at-midnight`  | Split entries spanning over multiple days at midnight.                     |
 
+##### Example
+
+This is an example configuration for a 35-hour week
+in which Fridays are a half workday and weekends off.
+Additionally, 3 hours and 23 minutes of pre-existing overtime are taken into account,
+and work is counted for the day it happened on.
+```
+flextime.time_per_day 7h30m
+flextime.time_per_day.friday 5h
+flextime.time_per_day.saturday 0h
+flextime.time_per_day.sunday 0h
+flextime.offset_total 3h23m
+flextime.aggregation_strategy split-at-midnight
+```
+
 #### Install
 
 After cloning the repo, build directly into your timewarrior extensions

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ flextime take it into account by setting a global offset.
 
 The following configuration keys are supported:
 
-| Key                             | Type     | Default           | Description                                   |
-|---------------------------------|----------|-------------------|-----------------------------------------------|
-| `flextime.time_per_day`         | Duration | `8h`              | Daily time target.                            |
-| `flextime.offset_total`         | Duration | `0`               | Time spent or lacking from a previous period. |
-| `flextime.aggregation_strategy` | Enum     | `single-day-only` | Strategy to use for aggregating the entries.  |
-| `verbose`                       | Bool     | true              | Print daily sums.                             |
-| `debug`                         | Bool     | false             | Enable debug output.                          |
+| Key                               | Type     | Default                           | Description                                   |
+|-----------------------------------|----------|-----------------------------------|-----------------------------------------------|
+| `flextime.time_per_day`           | Duration | `8h`                              | Default daily time target.                    |
+| `flextime.time_per_day.<weekday>` | Duration | value of `flextime.time_per_day`  | Weekday specific time target.                 |
+| `flextime.offset_total`           | Duration | `0`                               | Time spent or lacking from a previous period. |
+| `flextime.aggregation_strategy`   | Enum     | `single-day-only`                 | Strategy to use for aggregating the entries.  |
+| `verbose`                         | Bool     | true                              | Print daily sums.                             |
+| `debug`                           | Bool     | false                             | Enable debug output.                          |
 
 Durations must be given in a format supported by
 [go's time duration parser][go-time-duration].

--- a/cmd/flextime/config_test.go
+++ b/cmd/flextime/config_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024 Tobias Böhm <code@aibor.de>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aibor/timewarrior-extensions/twext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadTimeTargetConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   twext.Config
+		expected timeTargets
+		errorMsg string
+	}{
+		{
+			name:   "empty config",
+			config: twext.Config{},
+			expected: timeTargets{
+				weekdays:        map[time.Weekday]time.Duration{},
+				defaultDuration: 8 * time.Hour,
+			},
+		},
+		{
+			name: "just default",
+			config: twext.Config{
+				"flextime.time_per_day": "7h",
+			},
+			expected: timeTargets{
+				weekdays:        map[time.Weekday]time.Duration{},
+				defaultDuration: 7 * time.Hour,
+			},
+		},
+		{
+			name: "invalid default",
+			config: twext.Config{
+				"flextime.time_per_day": "a lot",
+			},
+			errorMsg: "time: invalid duration",
+		},
+		{
+			name: "all weekdays",
+			config: twext.Config{
+				"flextime.time_per_day.monday":    "1h",
+				"flextime.time_per_day.tuesday":   "2h",
+				"flextime.time_per_day.wednesday": "3h",
+				"flextime.time_per_day.thursday":  "4h",
+				"flextime.time_per_day.friday":    "5h",
+				"flextime.time_per_day.saturday":  "6h",
+				"flextime.time_per_day.sunday":    "7h",
+			},
+			expected: timeTargets{
+				weekdays: map[time.Weekday]time.Duration{
+					time.Monday:    1 * time.Hour,
+					time.Tuesday:   2 * time.Hour,
+					time.Wednesday: 3 * time.Hour,
+					time.Thursday:  4 * time.Hour,
+					time.Friday:    5 * time.Hour,
+					time.Saturday:  6 * time.Hour,
+					time.Sunday:    7 * time.Hour,
+				},
+				defaultDuration: 8 * time.Hour,
+			},
+		},
+		{
+			name: "invalid weekday",
+			config: twext.Config{
+				"flextime.time_per_day.saturday": "nothing",
+			},
+			errorMsg: "time: invalid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := readTimeTargetConfig(tt.config)
+
+			if tt.errorMsg != "" {
+				require.ErrorContains(t, err, tt.errorMsg)
+
+				return
+			}
+
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/cmd/flextime/main.go
+++ b/cmd/flextime/main.go
@@ -88,6 +88,7 @@ func run(inR io.ReadSeeker, outW, errW io.Writer) error {
 
 	if cfg.debug {
 		log.SetOutput(errW)
+		log.Println("cfg - Offset:", cfg.offset)
 		log.Println("cfg - Target:", cfg.timeTargets)
 		log.Println("cfg - AggregationStrategy:", cfg.aggregationStrategy)
 		log.Println("cfg - Debug:", cfg.debug)

--- a/cmd/flextime/main_internal_test.go
+++ b/cmd/flextime/main_internal_test.go
@@ -157,8 +157,46 @@ flextime.aggregation_strategy: split-at-midnight
 `,
 		},
 		{
+			name: "no work on weekends",
+			input: `verbose: on
+flextime.time_per_day.saturday: 0m
+flextime.time_per_day.sunday: 0m
+
+[
+{"id":4,"start":"20250220T082128Z","end":"20250220T123031Z"},
+{"id":3,"start":"20250220T130204Z","end":"20250220T181716Z"},
+{"id":2,"start":"20250221T143940Z","end":"20250221T173943Z"},
+{"id":1,"start":"20250222T091011Z","end":"20250222T135142Z"}
+]`,
+			expectedStdout: `
+          date     actual     target       diff
+    2025-02-20     9h:24m     8h:00m     1h:24m
+    2025-02-21     3h:00m     8h:00m    -4h:59m
+    2025-02-22     4h:41m     0h:00m     4h:41m
+         total    17h:05m    16h:00m     1h:05m
+`,
+		},
+		{
+			name: "less work on Friday",
+			input: `verbose: on
+flextime.time_per_day.friday: 4h
+
+[
+{"id":3,"start":"20250220T082128Z","end":"20250220T123031Z"},
+{"id":2,"start":"20250220T130204Z","end":"20250220T181716Z"},
+{"id":1,"start":"20250221T143940Z","end":"20250221T173943Z"}
+]`,
+			expectedStdout: `
+          date     actual     target       diff
+    2025-02-20     9h:24m     8h:00m     1h:24m
+    2025-02-21     3h:00m     4h:00m    -0h:59m
+         total    12h:24m    12h:00m     0h:24m
+`,
+		},
+		{
 			name: "debug",
 			input: `debug: on
+flextime.time_per_day.wednesday: 4h
 
 [
 {"id":3,"start":"20240629T102128Z","end":"20240630T102131Z"}
@@ -167,7 +205,7 @@ flextime.aggregation_strategy: split-at-midnight
      date    actual    target      diff
     total    0h:00m    0h:00m    0h:00m
 `,
-			expectedStderr: `debug [flextime] - cfg - DailyTarget: 8h0m0s
+			expectedStderr: `debug [flextime] - cfg - Target: Default: 8h0m0s Wednesday: 4h0m0s
 debug [flextime] - cfg - AggregationStrategy: single-day-only
 debug [flextime] - cfg - Debug: true
 debug [flextime] - cfg - Verbose: false

--- a/cmd/flextime/main_internal_test.go
+++ b/cmd/flextime/main_internal_test.go
@@ -205,7 +205,8 @@ flextime.time_per_day.wednesday: 4h
      date    actual    target      diff
     total    0h:00m    0h:00m    0h:00m
 `,
-			expectedStderr: `debug [flextime] - cfg - Target: Default: 8h0m0s Wednesday: 4h0m0s
+			expectedStderr: `debug [flextime] - cfg - Offset: 0s
+debug [flextime] - cfg - Target: Default: 8h0m0s Wednesday: 4h0m0s
 debug [flextime] - cfg - AggregationStrategy: single-day-only
 debug [flextime] - cfg - Debug: true
 debug [flextime] - cfg - Verbose: false


### PR DESCRIPTION
Yet another draft ~~(but incompatible with my other PR)~~. This one implements and closes #5.

I am unhappy with the duplicate code for all the weekdays, maybe using a hash map would work better. It will definitely not stay the way it is right now.